### PR TITLE
Licensing help

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016 Gregory Malecha
+Copyright (c) <year> <plugin's author>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -17,5 +17,7 @@ Get up and running in a few simple steps:
   5) Update the ```_CoqProject``` file to reflect your name.
 
   6) Run ```make``` and check out ```test-suite/demo.v```
+  
+  7) Update the LICENSE file by completing the line for your copyright claim or add your own license statement if you don't want to use MIT.
 
 All done.


### PR DESCRIPTION
I have seen people using your template for their plugin consistently forgetting to add their own name to the LICENSE file.

The most recent example is here: https://github.com/ppedrot/coq-string-ident/blob/master/LICENSE

This pull request adds a step to the README and an additional place to fill for users of the plugin template so that nobody forgets in the future.
